### PR TITLE
Do not enforce LF endings in binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,22 @@
 * text eol=lf
+
+# Do not enforce LF endings in binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.eot binary
+*.woff binary
+*.pyc binary
+*.pdf binary


### PR DESCRIPTION
The current `.gitattributes` file enforces Unix LF endings over Windows CRLF. However, as noted by [this StackOverflow thread](https://stackoverflow.com/a/56836491), Git regards images as text instead of binary and states them to be modified despite no modifications being made.

Indicating media files as binary prevents them from being mislabeled. 

The commit was based off the [`.gitattributes` template file in this repo](https://github.com/alexkaratarakis/gitattributes/blob/master/Web.gitattributes). 