### PR TITLE
Implement tag querying in project/challenge pages

### DIFF
--- a/app/templates/initiative.html
+++ b/app/templates/initiative.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% get_media_prefix %}
 {% load mistune %}
+{% load class_name %}
 
 {% block head %}
 <title>{{ initiative.name }} | Stratus</title>
@@ -49,7 +50,7 @@
             <div class="tile__container">
               <p class="tile__title">Tags:
                 {% for tag in initiative.tags.all %}
-                  <span class="tag white" style="background-color: {{ tag.color }}">{{ tag.name }}</span>
+                  <a href="{% url 'index' %}?type={{ initiative|class_name|lower }}&tag={{ tag.name }}" class="tag white" style="background-color: {{ tag.color }}">{{ tag.name }}</a>
                 {% endfor %}
               </p>
             </div>

--- a/app/templatetags/class_name.py
+++ b/app/templatetags/class_name.py
@@ -1,0 +1,7 @@
+from django import template
+
+register = template.Library()
+
+@register.filter(name="class_name")
+def get_class_name(model):
+	return model.__class__.__name__


### PR DESCRIPTION
On a project or challenge page, users can click on a tag to find projects or challenges with the same tag.

Relies on work from #27

Partial implementation of #15