### PR TITLE
Fix YouTube social link fixture

### DIFF
--- a/app/fixtures/social_links.json
+++ b/app/fixtures/social_links.json
@@ -75,7 +75,7 @@
   "fields": {
     "name": "YouTube",
     "icon": "youtube-play",
-    "site": "https://youtube.com/channel/",
+    "site": "https://youtube.com/user/%s",
     "placeholder": "Youtube Channel ID"
   }
 },


### PR DESCRIPTION
Adds a placeholder to the string. YouTube also seemed to have changed "channel" to "user". 